### PR TITLE
GTS-PRINT# : refactor calendar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,32 @@ Created By: BENGUERGOURA Oussama & HADJERSI Mohamed | 20/10/2024
 
 ### Added
 
+* Add the a simple `CalendarComponent` with the minimum of configuration (Show Readme)
+
+### Changed
+
+* The name of `CalendarComponent` is changed to `PureCalendar`.
+
+### Deprecated
+
+### Removed
+
+* The handling of timeslots displaying should be in the projects that use this lib.
+
+### Fixed
+
+### Security
+
+
+
+## [1.0.6] 
+
+### Added
+
 * Exporting all style directory (colors , fonts , ...) to be used in projects hosts .
 * Add `noBind` prop in `CheckBox` to prevent auto toggle on click and juste toggle if `isChecked` changed.  [GTS-PRINT#40] (https://quire.io/w/GTS-PRINT31/40)
 
 ### Changed
-
-* Changed `NoContent`component directory name.
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gts-print",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": false,
   "main": "dist/gts-print.cjs.js",
   "module": "dist/gts-print.es.js",
@@ -23,6 +23,7 @@
     "@mdi/font": "5.9.55",
     "core-js": "^3.8.3",
     "maska": "^3.0.3",
+    "moment": "^2.30.1",
     "roboto-fontface": "*",
     "vite-plugin-vuetify": "^2.1.0",
     "vue": "^3.2.13",

--- a/src/components/calendar/CalendarComponent.vue
+++ b/src/components/calendar/CalendarComponent.vue
@@ -1,92 +1,195 @@
 <template>
 
-  <div class="">
-    
-    <!-- calendar header -->
-    <CalendarHeader 
-      :startDate="headerConfig.startDate"
-      :endDate="headerConfig.endDate"
-      :calendarTypes="headerConfig.calendarTypes"
-      :defaultType="headerConfig.defaultType"
-      @dateIncremented="onDateIncremented"
-      @dateDecremented="onDateDecremented"
-      @dispalyTypeSelected="onDisplayTypeSelected"
-    />
+  <PureCalendar :headerConfig="headerConfig" :calendarContentConfig="calendarContentConfig"
+    @dateIncremented="showNextCalendarIntervalPage" @dateDecremented="showPreviousCalendarIntervalPage"
+    @displayTypeSelected="handleDisplayTypeSelected" />
 
-    <!-- dynamic display -->
-    <component 
-      :is="calendarContentConfig.selectedCalendarComponent" 
-      :calendarData="calendarContentConfig.calendarData"
-    />
-
-  </div>
-    
 </template>
 
 <script>
+import { CALENDARS_MONTH_TYPE, CALENDARS_TYPES } from '@/constants/calendars';
+import PureCalendar from './PureCalendar.vue';
+import moment from 'moment';
 
-import CalendarHeader from './CalendarHeader.vue';
-import CalendarMonthly from './month/CalendarMonthly.vue';
-import CalendarWeekly from './week/CalendarWeekly.vue';
+
+
 
 export default {
 
   name: "CalendarComponent",
 
-  emits: ['dateIncremented', 'dateDecremented', 'displayTypeSelected'],
-
   components: {
-    CalendarHeader,
-    CalendarMonthly,
-    CalendarWeekly,
+    PureCalendar
+  },
+  emits: ['onDateChanged'],
+
+  created() {
+
+    if(this.startingDate){
+      this.selectedStartDate = moment(this.startingDate, 'DD/MM/YYYY');
+    }
+    
+    
+    const currentDateString = this.selectedStartDate.format('DD/MM/YYYY')
+
+    this.setUpDaysOfTheWeek();
+
+    this.generateCalendarPage(currentDateString)
+
   },
 
   props: {
-    headerConfig: {
-      type: Object,
-      required: true,
-      default: () => ({
-        startDate: '',
-        endDate: '',
-        calendarTypes: [],
-        defaultType: '',
-      }),
+    startingDate: {
+      type: String,
+      required: false,
+      default : moment().format('DD/MM/YYYY')
     },
-    calendarContentConfig: {
-      type: Object,
-      required: true,
-      default: () => ({
-        selectedCalendarComponent: 'CalendarMonthly',
-        calendarData: {},
-      }),
-    },
+    datesContent:{
+      type: Array,
+      required: false,
+      default : Array.of()
+
+    }
+
   },
 
-  data () {
+  data() {
     return {
+      selectedStartDate: moment(),
+      headerConfig: {
+        calendarTypes: CALENDARS_TYPES,
+        defaultType: CALENDARS_MONTH_TYPE,
+      },
+
+      calendarContentConfig: {
+        selectedCalendarComponent: 'CalendarMonthly',
+        calendarData: {},
+      },
     }
   },
 
-  methods : {
-    
-    onDateIncremented() {
-      this.$emit('dateIncremented');
+  methods: {
+
+    setUpDaysOfTheWeek() {
+      const currentDate = moment();
+
+      const startOfWeek = currentDate.clone().startOf('week');
+
+      // Dernier jour de la semaine (samedi)
+      const endOfWeek = currentDate.clone().endOf('week');
+      // Affichage des noms des jours de la semaine
+      let daysOfWeek = [];
+      for (let day = startOfWeek; day.isBefore(endOfWeek) || day.isSame(endOfWeek, 'day'); day.add(1, 'days')) {
+        daysOfWeek.push(day.format('ddd').toUpperCase());  // Format du jour (ex: 'Sun', 'Mon', etc.)
+      }
+
+
+      this.calendarContentConfig.calendarData
+        .weekDays = daysOfWeek;
     },
 
-    onDateDecremented() {
-      this.$emit('dateDecremented');
+    generateCalendarPage(from) {
+
+      const currentDate = moment(from, 'DD/MM/YYYY');
+
+      let startOfCalendar = undefined;
+      let endOfCalendar = undefined;
+
+      if (this.headerConfig.defaultType == CALENDARS_MONTH_TYPE) {
+        startOfCalendar = currentDate.clone().startOf('month').startOf('week');
+        endOfCalendar = currentDate.clone().endOf('month').endOf('week');
+      } else {
+        startOfCalendar = currentDate.clone().startOf('week');
+        endOfCalendar = currentDate.clone().endOf('week');
+      }
+
+      this.headerConfig.startDate = startOfCalendar.format('DD MMM');
+      this.headerConfig.endDate = endOfCalendar.format('DD MMM');
+
+      // Générer toutes les dates dans cette plage
+      let calendarRange = [];
+      let day = startOfCalendar.clone();
+      for (day; day.isBefore(endOfCalendar) || day.isSame(endOfCalendar, 'day'); day.add(1, 'days')) {
+        
+        let dateContent = this.datesContent.find(dateContent => dateContent.date == day.format('DD/MM/YYYY'));
+       
+        let content = dateContent ? dateContent.content : undefined ;
+
+        calendarRange.push(
+          {
+            date: day.format('DD/MM/YYYY'),
+            number: day.format('DD'),
+            day: day.format('ddd').toUpperCase(),
+            label: "NO EVENT",
+            disabled: true,
+            content
+          }
+        );
+      }
+
+      this.calendarContentConfig
+        .calendarData
+        .calendars = this.chunkArray(calendarRange, 7);
+
     },
 
-    onDisplayTypeSelected(displayType) {
-      this.$emit('displayTypeSelected', displayType);
+    chunkArray(array, size) {
+      return array.reduce((acc, _, i) => {
+        if (i % size === 0) acc.push(array.slice(i, i + size));
+        return acc;
+      }, []);
+    },
+    showNextCalendarIntervalPage() {
+
+      let { lastCalendarDate } = this.getFirstAndLastCalendarDates();
+
+      const currentDate = moment(lastCalendarDate, 'DD/MM/YYYY').add(1, 'days');
+      this.generateCalendarPage(currentDate.format('DD/MM/YYYY'));
+
+      this.$emit("onDateChanged", this.getFirstAndLastCalendarDates())
+
+    },
+    showPreviousCalendarIntervalPage() {
+
+      let { firstCalendarDate } = this.getFirstAndLastCalendarDates()
+
+      const currentDate = moment(firstCalendarDate, 'DD/MM/YYYY').add(-1, 'days');
+
+      this.generateCalendarPage(currentDate.format('DD/MM/YYYY'))
+
+      this.$emit("onDateChanged", this.getFirstAndLastCalendarDates())
+
     },
 
-  }
+    getFirstAndLastCalendarDates() {
+      let calendarGeneratedDates = this.calendarContentConfig
+        .calendarData
+        .calendars;
+
+      let firstCalendarWeek = calendarGeneratedDates[0];
+      let firstCalendarDate = firstCalendarWeek[0].date;
+
+      let lastCalendarWeek = calendarGeneratedDates[calendarGeneratedDates.length - 1];
+      let lastCalendarDate = lastCalendarWeek[lastCalendarWeek.length - 1].date;
+
+      return { firstCalendarDate, lastCalendarDate }
+
+    },
+    handleDisplayTypeSelected(type) {
+      this.headerConfig.defaultType = type;
+
+      if (type == CALENDARS_MONTH_TYPE) {
+        this.calendarContentConfig.selectedCalendarComponent = 'CalendarMonthly';
+      } else {
+        this.calendarContentConfig.selectedCalendarComponent = 'CalendarWeekly';
+
+      }
+      this.generateCalendarPage(this.selectedStartDate);
+    }
+
+  },
 
 }
 </script>
 
-<style lang="scss">
-
-
-</style>
+<style lang="scss"></style>

--- a/src/components/calendar/CalendarExample.vue
+++ b/src/components/calendar/CalendarExample.vue
@@ -1,7 +1,17 @@
 <template>
 
   <div id="exemple-container">
-    <CalendarComponent 
+
+    <span>GTS-CALENDAR : Navigate to Mars and May to show mor effect</span> <br>
+    <CalendarComponent
+    :datesContent="dummyContent"
+    :startingDate="'25/05/2025'"
+    @onDateChanged="($emit) => console.log($emit)"
+     /> <br>
+
+
+     <span>PURE CONGURABLE CALENDAR : </span> <br>
+    <PureCalendar 
       :headerConfig="headerConfig"
       :calendarContentConfig="calendarContentConfig"
       @dateIncremented="handleDateIncremented"
@@ -14,23 +24,50 @@
 
 <script>
 
-import CalendarComponent from './CalendarComponent.vue';
-
+import PureCalendar from './PureCalendar.vue';
 import {CALENDARS_TYPES, CALENDARS_MONTH_TYPE, CALENDARS_WEEK_TYPE} from '@/constants/calendars.js';
 import UpdateIcon from '@/assets/icons/UpdateIcon.vue';
 import DeleteIcon from '@/assets/icons/DeleteIcon.vue';
 import { defineComponent, markRaw } from 'vue';
+import CalendarComponent from './CalendarComponent.vue';
+ 
 
 export default {
 
   name: "CalendarExample",
 
   components: {
-    CalendarComponent
+    CalendarComponent,
+    PureCalendar
   },
 
   data() {
     return {
+     dummyContent: [
+     {
+       date: '12/03/2025',
+       content: markRaw(defineComponent({
+        template: `<div>i have content for 12/03/2025</div>`
+       }))
+     },
+     {
+       date: '21/03/2025',
+       content: markRaw(defineComponent({
+        template: `<div>i have content for 12/03/2025</div>`
+       }))
+     },
+     {
+       date: '19/05/2025',
+       content: markRaw(defineComponent({
+        methods:{
+          onClick()  {
+            alert("Content clicked !")
+          }
+        },
+        template: `<div class="calendar-content-test" @click="onClick">click me : 19/05/2025</div>`
+       }))
+     }
+    ],
 
       headerConfig: {
         startDate: '01 Jan',
@@ -292,4 +329,11 @@ export default {
 
 </script>
 
-<style lang="scss"></style>
+<style lang="scss">
+
+
+.calendar-content-test {
+  background-color: green;
+}
+
+</style>

--- a/src/components/calendar/PureCalendar.vue
+++ b/src/components/calendar/PureCalendar.vue
@@ -1,0 +1,92 @@
+<template>
+
+  <div class="">
+    
+    <!-- calendar header -->
+    <CalendarHeader 
+      :startDate="headerConfig.startDate"
+      :endDate="headerConfig.endDate"
+      :calendarTypes="headerConfig.calendarTypes"
+      :defaultType="headerConfig.defaultType"
+      @dateIncremented="onDateIncremented"
+      @dateDecremented="onDateDecremented"
+      @dispalyTypeSelected="onDisplayTypeSelected"
+    />
+
+    <!-- dynamic display -->
+    <component 
+      :is="calendarContentConfig.selectedCalendarComponent" 
+      :calendarData="calendarContentConfig.calendarData"
+    />
+
+  </div>
+    
+</template>
+
+<script>
+
+import CalendarHeader from './CalendarHeader.vue';
+import CalendarMonthly from './month/CalendarMonthly.vue';
+import CalendarWeekly from './week/CalendarWeekly.vue';
+
+export default {
+
+  name: "PureCalendar",
+
+  emits: ['dateIncremented', 'dateDecremented', 'displayTypeSelected'],
+
+  components: {
+    CalendarHeader,
+    CalendarMonthly,
+    CalendarWeekly,
+  },
+
+  props: {
+    headerConfig: {
+      type: Object,
+      required: true,
+      default: () => ({
+        startDate: '',
+        endDate: '',
+        calendarTypes: [],
+        defaultType: '',
+      }),
+    },
+    calendarContentConfig: {
+      type: Object,
+      required: true,
+      default: () => ({
+        selectedCalendarComponent: 'CalendarMonthly',
+        calendarData: {},
+      }),
+    },
+  },
+
+  data () {
+    return {
+    }
+  },
+
+  methods : {
+    
+    onDateIncremented() {
+      this.$emit('dateIncremented');
+    },
+
+    onDateDecremented() {
+      this.$emit('dateDecremented');
+    },
+
+    onDisplayTypeSelected(displayType) {
+      this.$emit('displayTypeSelected', displayType);
+    },
+
+  }
+
+}
+</script>
+
+<style lang="scss">
+
+
+</style>

--- a/src/components/calendar/README.md
+++ b/src/components/calendar/README.md
@@ -1,8 +1,8 @@
-# `CalendarComponent` Documentation
+# `PureCalendar` Documentation
 
 ## Introduction
 
-The `CalendarComponent` component is designed for displaying calendar data and `CalendarHeader` acocrding to a specific properties,
+The `PureCalendar` component is designed for displaying calendar data and `CalendarHeader` acocrding to a specific properties,
 the aim of this component is to display a data on three diffrent display mode `Month`, `Week`, `Day`,
 
 
@@ -313,3 +313,34 @@ calendars: [
       },
       },
 ```
+
+
+# `CalendarComponent` Documentation
+
+## Introduction
+
+The `CalendarComponent` component is designed for displaying calendar dates and show specific content into each date cell in the calendar.
+
+
+## Props
+
+| Prop                      | Type    | Required  | Default                       | Description                                                    |
+|---------------------------|---------|-----------|-------------------------------|----------------------------------------------------------------|
+| `startingDate`            | String  | No       | `see default values section`  | Its represent the first month to display when calendar is mounted|
+| `datesContent`   | Array  | No       | `see default values section ` | Its represent calendar data content |
+
+### Events
+
+| Event                   | Description                                        |
+|-------------------------|----------------------------------------------------|
+| `@onDateChanged`      | Emitted when header next/prev button is clicked. the returned data is like : {firstCalendarDate: '01/06/2025', lastCalendarDate: '05/07/2025'}     |
+
+```vue
+<CalendarComponent
+    :datesContent="dummyContent"
+    :startingDate="'25/05/2025'"
+    @onDateChanged="($emit) => console.log($emit)"
+     />
+
+```
+ 

--- a/src/components/calendar/month/CalendarMonthly.vue
+++ b/src/components/calendar/month/CalendarMonthly.vue
@@ -72,7 +72,7 @@ export default {
           if (this.selectedDay === day) {
             return "selected";
           }
-          if (day.timeSlots.length === 0) {
+          if (day.disabled) {
             return "light-gray";
           }
           return "";
@@ -84,7 +84,7 @@ export default {
   methods : {
 
     selectDay(day){
-      if(day.timeSlots.length>0)
+      if(!day.disabled)
         this.selectedDay = day;
     },
 

--- a/src/components/calendar/month/CalendarMonthlyInfo.vue
+++ b/src/components/calendar/month/CalendarMonthlyInfo.vue
@@ -16,10 +16,8 @@
   </div>
 
   <!-- timeslot  -->
-  <div v-if="calendarDay.timeSlots.length > 0" class="gts-print-calendar-monthly-content-data-timeslots">
-    <div class="gts-print-calendar-monthly-content-data-timeslot" v-for="timeSlot in calendarDay.timeSlots" :key="timeSlot">
-      <span class="time-slot-text"> {{timeSlot.startTime}} - {{timeSlot.endTime}}</span>
-    </div>
+  <div v-if="calendarDay.content" class="gts-print-calendar-monthly-content-data-timeslots">   
+    <component :is="calendarDay.content" />
   </div>
 
   <!-- empty content  -->

--- a/src/components/calendar/week/CalendarWeekly.vue
+++ b/src/components/calendar/week/CalendarWeekly.vue
@@ -43,7 +43,7 @@ export default {
         if (this.selectedDay === day) {
           return "selected";
         }
-        if (day.timeSlots.length === 0) {
+        if (day.disabled) {
           return "light-gray";
         }
         return "";

--- a/src/components/calendar/week/CalendarWeeklyInfo.vue
+++ b/src/components/calendar/week/CalendarWeeklyInfo.vue
@@ -12,15 +12,11 @@
     <div class="gts-print-calendar-weekly-content-separator"></div>
 
     <!-- timeslot -->
-    <div v-if="calendarDay.timeSlots.length > 0" class="gts-print-calendar-weekly-content-data">
+    <div v-if="calendarDay.content" class="gts-print-calendar-weekly-content-data">
   
       <span class="gts-print-calendar-weekly-content-data-label"> {{ calendarDay.label }} </span>
       
-      <div class="gts-print-calendar-weekly-content-data-timeslots">
-        <div class="gts-print-calendar-weekly-content-data-timeslot" v-for="timeSlot in calendarDay.timeSlots" :key="timeSlot">
-          <span class="time-slot-text"> {{timeSlot.startTime}} - {{timeSlot.endTime}}</span>
-        </div>
-      </div>
+      <component :is="calendarDay.content" />
       
     </div>
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import BadgeComponent from '@/components/badge/BadgeComponent.vue';
 import CardComponent from '@/components/card/CardComponent.vue';
 import StepperComponent from '@/components/stepper/StepperComponent.vue';
 import ToolTip from '@/components/tooltip/ToolTip.vue';
-import CalendarComponent from '@/components/calendar/CalendarComponent.vue';
+import CalendarComponent from '@/components/calendar/PureCalendar.vue';
 import NoContent from '@/components/nocontent/NoContent.vue';
 
 const GtsPrint = {


### PR DESCRIPTION
* Add the a simple CalendarComponent with the minimum of configuration (Show Readme)
* The name of CalendarComponent is changed to PureCalendar.
* The handling of timeslots displaying should be in the projects that use this lib.