### PR TITLE
Enhance component styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Created By: BENGUERGOURA Oussama & HADJERSI Mohamed | 20/10/2024
 
+
 ## [Unreleased] 
+
+### Added
+
+### Changed
+
+* `Input` has no default `min-height` now.
+* `ButtonComponent`:
+    - has default `width: fit-content` to prevent occupating all ligne space.
+    - Making content to center.
+
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+
+## [1.0.18] 
 
 ### Added
 

--- a/src/components/button/ButtonComponent.vue
+++ b/src/components/button/ButtonComponent.vue
@@ -111,6 +111,7 @@ export default {
 <style lang="scss">
 .gts-button-container {
 	display: inline-flex;
+	width: fit-content;
 
 	
 
@@ -130,6 +131,8 @@ export default {
 
 		.gts-button-content {
 		display: flex;
+		align-items: center;
+		justify-content: center;
 	
 		.gts-button-icon {
 			display: flex;

--- a/src/components/input/input-common-css.scss
+++ b/src/components/input/input-common-css.scss
@@ -21,9 +21,6 @@
 
 }
 
-.gts-input:not(.gts-listbox) {
-  min-width: 400px;
-}
 
 .gts-input:focus {
     border-color: $primary-color-400;


### PR DESCRIPTION
* Input has no default min-height now.
* ButtonComponent:
    - has default width: fit-content to prevent occupating all ligne space.
    - Making content to center.